### PR TITLE
Fix for sideways images from camera on iOS 4.x

### DIFF
--- a/Classes/ELCImagePickerController.m
+++ b/Classes/ELCImagePickerController.m
@@ -30,7 +30,12 @@
 
 		NSMutableDictionary *workingDictionary = [[NSMutableDictionary alloc] init];
 		[workingDictionary setObject:[asset valueForProperty:ALAssetPropertyType] forKey:@"UIImagePickerControllerMediaType"];
-        [workingDictionary setObject:[UIImage imageWithCGImage:[[asset defaultRepresentation] fullScreenImage]] forKey:@"UIImagePickerControllerOriginalImage"];
+    ALAssetRepresentation *assetRep = [asset defaultRepresentation];
+    CGImageRef imgRef = [assetRep fullScreenImage];
+    UIImage *img = [UIImage imageWithCGImage:imgRef
+                                       scale:assetRep.scale
+                                 orientation:(UIImageOrientation)assetRep.orientation];
+    [workingDictionary setObject:img forKey:@"UIImagePickerControllerOriginalImage"];
 		[workingDictionary setObject:[[asset valueForProperty:ALAssetPropertyURLs] valueForKey:[[[asset valueForProperty:ALAssetPropertyURLs] allKeys] objectAtIndex:0]] forKey:@"UIImagePickerControllerReferenceURL"];
 		
 		[returnArray addObject:workingDictionary];


### PR DESCRIPTION
Previous to iOS 5, the fullScreenImage method of ALAssetRepresentation
doesn't return a correctly oriented CGImage, so the UIImage has to be
created with specified scale and orientation to prevent sideways and
upside-down images on iOS 4 devices.
