### PR TITLE
Fix for Camera Albums order

### DIFF
--- a/Classes/ELCAlbumPickerController.m
+++ b/Classes/ELCAlbumPickerController.m
@@ -44,7 +44,16 @@
                 return;
             }
             
-            [self.assetGroups addObject:group];
+            // added fix for camera albums order
+            NSString *sGroupPropertyName = (NSString *)[group valueForProperty:ALAssetsGroupPropertyName];
+            NSUInteger nType = [[group valueForProperty:ALAssetsGroupPropertyType] intValue];
+            
+            if ([[sGroupPropertyName lowercaseString] isEqualToString:@"camera roll"] && nType == ALAssetsGroupSavedPhotos) {
+                [self.assetGroups insertObject:group atIndex:0];
+            }
+            else {
+                [self.assetGroups addObject:group];
+            }
 
             // Reload albums
             [self performSelectorOnMainThread:@selector(reloadTableView) withObject:nil waitUntilDone:YES];


### PR DESCRIPTION
Fix for Camera Album order. The "Camera Roll" should be displayed first in the ELCAlbumPickerController
