### PR TITLE
'dismissModalViewControllerAnimated:' is deprecated:

### DIFF
--- a/Classes/ELCImagePickerController.m
+++ b/Classes/ELCImagePickerController.m
@@ -39,7 +39,7 @@
 	}
 	
     [self popToRootViewControllerAnimated:NO];
-    [[self parentViewController] dismissModalViewControllerAnimated:YES];
+    [[self parentViewController] dismissViewControllerAnimated:YES completion:nil];
     
 	if([delegate respondsToSelector:@selector(elcImagePickerController:didFinishPickingMediaWithInfo:)]) {
 		[delegate performSelector:@selector(elcImagePickerController:didFinishPickingMediaWithInfo:) withObject:self withObject:[NSArray arrayWithArray:returnArray]];

--- a/Classes/ELCImagePickerDemoViewController.m
+++ b/Classes/ELCImagePickerDemoViewController.m
@@ -23,7 +23,7 @@
 	[elcPicker setDelegate:self];
     
     ELCImagePickerDemoAppDelegate *app = (ELCImagePickerDemoAppDelegate *)[[UIApplication sharedApplication] delegate];
-	[app.viewController presentModalViewController:elcPicker animated:YES];
+    [app.viewController presentViewController:elcPicker animated:YES completion:nil];
     [elcPicker release];
     [albumController release];
 }
@@ -32,7 +32,7 @@
 
 - (void)elcImagePickerController:(ELCImagePickerController *)picker didFinishPickingMediaWithInfo:(NSArray *)info {
 	
-	[self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 	
     for (UIView *v in [scrollview subviews]) {
         [v removeFromSuperview];
@@ -59,7 +59,7 @@
 
 - (void)elcImagePickerControllerDidCancel:(ELCImagePickerController *)picker {
 
-	[self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
'dismissModalViewControllerAnimated:' is deprecated:
first deprecated in iOS 6.0
