### PR TITLE
Fix demo project crashes

### DIFF
--- a/Classes/ELCImagePicker/ELCAlbumPickerController.m
+++ b/Classes/ELCImagePicker/ELCAlbumPickerController.m
@@ -141,7 +141,7 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
 	
-	ELCAssetTablePicker *picker = [[ELCAssetTablePicker alloc] initWithNibName:@"ELCAssetTablePicker" bundle:[NSBundle mainBundle]];
+	ELCAssetTablePicker *picker = [[ELCAssetTablePicker alloc] initWithNibName: nil bundle: nil];
 	picker.parent = self;
 
     picker.assetGroup = [self.assetGroups objectAtIndex:indexPath.row];

--- a/Classes/ELCImagePickerDemoViewController.m
+++ b/Classes/ELCImagePickerDemoViewController.m
@@ -25,7 +25,7 @@
 
 - (IBAction)launchController
 {	
-    ELCAlbumPickerController *albumController = [[ELCAlbumPickerController alloc] initWithNibName:@"ELCAlbumPickerController" bundle:[NSBundle mainBundle]];    
+    ELCAlbumPickerController *albumController = [[ELCAlbumPickerController alloc] initWithNibName: nil bundle: nil];
 	ELCImagePickerController *elcPicker = [[ELCImagePickerController alloc] initWithRootViewController:albumController];
     [albumController setParent:elcPicker];
 	[elcPicker setDelegate:self];
@@ -68,7 +68,7 @@
 
 - (void)displayPickerForGroup:(ALAssetsGroup *)group
 {
-	ELCAssetTablePicker *tablePicker = [[ELCAssetTablePicker alloc] initWithNibName:@"ELCAssetTablePicker" bundle:[NSBundle mainBundle]];
+	ELCAssetTablePicker *tablePicker = [[ELCAssetTablePicker alloc] initWithNibName: nil bundle: nil];
     tablePicker.singleSelection = YES;
     tablePicker.immediateReturn = YES;
     


### PR DESCRIPTION
In demo project, if you click on either "Normal Picker" or "Limited Picker" button app crashes with log:
Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Could not load NIB in bundle: 'NSBundle </var/mobile/Applications/F5CEC86B-948D-4869-84D1-2BD6C1431655/ELCImagePickerDemo.app> (loaded)' with name 'ELCAlbumPickerController''

This kind of issues has been fixed.
