### PR TITLE
Added delegate for filtering the ELCAssetTablePicker

### DIFF
--- a/Classes/ELCImagePicker/ELCAlbumPickerController.h
+++ b/Classes/ELCImagePicker/ELCAlbumPickerController.h
@@ -8,11 +8,15 @@
 #import <UIKit/UIKit.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 #import "ELCAssetSelectionDelegate.h"
+#import "ELCAssetPickerFilterDelegate.h"
 
 @interface ELCAlbumPickerController : UITableViewController <ELCAssetSelectionDelegate>
 
 @property (nonatomic, assign) id<ELCAssetSelectionDelegate> parent;
 @property (nonatomic, retain) NSMutableArray *assetGroups;
+
+// optional, can be used to filter the assets displayed
+@property (nonatomic, assign) id<ELCAssetPickerFilterDelegate> assetPickerFilterDelegate;
 
 @end
 

--- a/Classes/ELCImagePicker/ELCAlbumPickerController.m
+++ b/Classes/ELCImagePicker/ELCAlbumPickerController.m
@@ -147,6 +147,8 @@
     picker.assetGroup = [self.assetGroups objectAtIndex:indexPath.row];
     [picker.assetGroup setAssetsFilter:[ALAssetsFilter allPhotos]];
     
+	picker.assetPickerFilterDelegate = self.assetPickerFilterDelegate;
+	
 	[self.navigationController pushViewController:picker animated:YES];
 	[picker release];
 }

--- a/Classes/ELCImagePicker/ELCAssetPickerFilterDelegate.h
+++ b/Classes/ELCImagePicker/ELCAssetPickerFilterDelegate.h
@@ -1,0 +1,9 @@
+@class ELCAsset;
+@class ELCAssetTablePicker;
+
+@protocol ELCAssetPickerFilterDelegate<NSObject>
+
+// respond YES/NO to filter out (not show the asset)
+-(BOOL)assetTablePicker:(ELCAssetTablePicker *)picker isAssetFilteredOut:(ELCAsset *)elcAsset;
+
+@end

--- a/Classes/ELCImagePicker/ELCAssetTablePicker.h
+++ b/Classes/ELCImagePicker/ELCAssetTablePicker.h
@@ -9,6 +9,7 @@
 #import <AssetsLibrary/AssetsLibrary.h>
 #import "ELCAsset.h"
 #import "ELCAssetSelectionDelegate.h"
+#import "ELCAssetPickerFilterDelegate.h"
 
 @interface ELCAssetTablePicker : UITableViewController <ELCAssetDelegate>
 
@@ -18,6 +19,9 @@
 @property (nonatomic, retain) IBOutlet UILabel *selectedAssetsLabel;
 @property (nonatomic, assign) BOOL singleSelection;
 @property (nonatomic, assign) BOOL immediateReturn;
+
+// optional, can be used to filter the assets displayed
+@property(nonatomic, assign) id<ELCAssetPickerFilterDelegate> assetPickerFilterDelegate;
 
 - (int)totalSelectedAssets;
 - (void)preparePhotos;

--- a/Classes/ELCImagePicker/ELCAssetTablePicker.m
+++ b/Classes/ELCImagePicker/ELCAssetTablePicker.m
@@ -76,7 +76,18 @@
 
         ELCAsset *elcAsset = [[ELCAsset alloc] initWithAsset:result];
         [elcAsset setParent:self];
-        [self.elcAssets addObject:elcAsset];
+        
+        BOOL isAssetFiltered = NO;
+        if (self.assetPickerFilterDelegate &&
+           [self.assetPickerFilterDelegate respondsToSelector:@selector(assetTablePicker:isAssetFilteredOut:)])
+        {
+	        isAssetFiltered = [self.assetPickerFilterDelegate assetTablePicker:self isAssetFilteredOut:(ELCAsset*)elcAsset];
+        }
+
+        if (!isAssetFiltered) {
+	        [self.elcAssets addObject:elcAsset];
+        }
+        
         [elcAsset release];
      }];
     NSLog(@"done enumerating photos");

--- a/ELCImagePickerDemo.xcodeproj/project.pbxproj
+++ b/ELCImagePickerDemo.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		83C6BC9514476B280064D71D /* elc-ios-icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "elc-ios-icon@2x.png"; sourceTree = "<group>"; };
 		83C6BC9614476B280064D71D /* elc-ios-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "elc-ios-icon.png"; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* ELCImagePickerDemo-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ELCImagePickerDemo-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
+		A58058B417EB865B0078600C /* ELCAssetPickerFilterDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ELCAssetPickerFilterDelegate.h; sourceTree = "<group>"; };
 		E29A5E3B1239C42A008BB149 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -164,6 +165,7 @@
 				1A2C100317026CF0004FAFA0 /* ELCAssetCell.h */,
 				1A2C100117026CF0004FAFA0 /* ELCAssetCell.m */,
 				230644B815F8A5A6007679C7 /* ELCAssetSelectionDelegate.h */,
+				A58058B417EB865B0078600C /* ELCAssetPickerFilterDelegate.h */,
 				1A2C0FFA17026CF0004FAFA0 /* ELCAssetTablePicker.h */,
 				1A2C0FFB17026CF0004FAFA0 /* ELCAssetTablePicker.m */,
 				1A2C100217026CF0004FAFA0 /* ELCImagePickerController.h */,


### PR DESCRIPTION
Added ELCAssetPickerFilterDelegate, so one can implement its protocol for assetTablePicker:isAssetFilteredOut:, and return YES/NO to filter out a given asset.
