### PR TITLE
Prevent a crash if the asset was deleted since being displayed

### DIFF
--- a/Classes/ELCImagePicker/ELCImagePickerController.m
+++ b/Classes/ELCImagePicker/ELCImagePickerController.m
@@ -43,6 +43,10 @@
 	NSMutableArray *returnArray = [[[NSMutableArray alloc] init] autorelease];
 	
 	for(ALAsset *asset in assets) {
+		id obj = [asset valueForProperty:ALAssetPropertyType];
+		if (!obj) {
+			continue;
+		}
 		NSMutableDictionary *workingDictionary = [[NSMutableDictionary alloc] init];
 		
 		CLLocation* wgs84Location = [asset valueForProperty:ALAssetPropertyLocation];
@@ -50,7 +54,7 @@
 			[workingDictionary setObject:wgs84Location forKey:ALAssetPropertyLocation];
 		}
     
-		[workingDictionary setObject:[asset valueForProperty:ALAssetPropertyType] forKey:@"UIImagePickerControllerMediaType"];
+		[workingDictionary setObject:obj forKey:@"UIImagePickerControllerMediaType"];
         ALAssetRepresentation *assetRep = [asset defaultRepresentation];
         
         CGImageRef imgRef = [assetRep fullScreenImage];


### PR DESCRIPTION
For example - open ELCImagePickerController and view assets in your Camera Roll, switch to the Photos app and delete a photo, switch back to ELC picker and choose the photo you deleted).
