### PR TITLE
Added support for asset deselection delegate messages.

### DIFF
--- a/Classes/ELCImagePicker/ELCAlbumPickerController.m
+++ b/Classes/ELCImagePicker/ELCAlbumPickerController.m
@@ -93,6 +93,11 @@
     return [self.parent shouldSelectAsset:asset previousCount:previousCount];
 }
 
+- (BOOL)shouldDeselectAsset:(ELCAsset *)asset previousCount:(NSUInteger)previousCount
+{
+    return [self.parent shouldDeselectAsset:asset previousCount:previousCount];
+}
+
 - (void)selectedAssets:(NSArray*)assets
 {
 	[_parent selectedAssets:assets];

--- a/Classes/ELCImagePicker/ELCAsset.h
+++ b/Classes/ELCImagePicker/ELCAsset.h
@@ -15,6 +15,8 @@
 @optional
 - (void)assetSelected:(ELCAsset *)asset;
 - (BOOL)shouldSelectAsset:(ELCAsset *)asset;
+- (void)assetDeselected:(ELCAsset *)asset;
+- (BOOL)shouldDeselectAsset:(ELCAsset *)asset;
 @end
 
 

--- a/Classes/ELCImagePicker/ELCAsset.m
+++ b/Classes/ELCImagePicker/ELCAsset.m
@@ -35,11 +35,21 @@
                 return;
             }
         }
+    } else {
+        if ([_parent respondsToSelector:@selector(shouldDeselectAsset:)]) {
+            if (![_parent shouldDeselectAsset:self]) {
+                return;
+            }
+        }
     }
     _selected = selected;
     if (selected) {
         if (_parent != nil && [_parent respondsToSelector:@selector(assetSelected:)]) {
             [_parent assetSelected:self];
+        }
+    } else {
+        if (_parent != nil && [_parent respondsToSelector:@selector(assetDeselected:)]) {
+            [_parent assetDeselected:self];
         }
     }
 }

--- a/Classes/ELCImagePicker/ELCAssetSelectionDelegate.h
+++ b/Classes/ELCImagePicker/ELCAssetSelectionDelegate.h
@@ -14,5 +14,6 @@
 
 - (void)selectedAssets:(NSArray *)assets;
 - (BOOL)shouldSelectAsset:(ELCAsset *)asset previousCount:(NSUInteger)previousCount;
+- (BOOL)shouldDeselectAsset:(ELCAsset *)asset previousCount:(NSUInteger)previousCount;
 
 @end

--- a/Classes/ELCImagePicker/ELCAssetTablePicker.m
+++ b/Classes/ELCImagePicker/ELCAssetTablePicker.m
@@ -154,6 +154,35 @@
     }
 }
 
+- (BOOL)shouldDeselectAsset:(ELCAsset *)asset
+{
+    NSUInteger selectionCount = 0;
+    for (ELCAsset *elcAsset in self.elcAssets) {
+        if (elcAsset.selected) selectionCount++;
+    }
+    BOOL shouldDeselect = YES;
+    if ([self.parent respondsToSelector:@selector(shouldDeselectAsset:previousCount:)]) {
+        shouldDeselect = [self.parent shouldDeselectAsset:asset previousCount:selectionCount];
+    }
+    return shouldDeselect;
+}
+
+- (void)assetDeselected:(ELCAsset *)asset
+{
+    if (self.singleSelection) {
+        for (ELCAsset *elcAsset in self.elcAssets) {
+            if (asset != elcAsset) {
+                elcAsset.selected = NO;
+            }
+        }
+    }
+
+    if (self.immediateReturn) {
+        NSArray *singleAssetArray = @[asset.asset];
+        [(NSObject *)self.parent performSelector:@selector(selectedAssets:) withObject:singleAssetArray afterDelay:0];
+    }
+}
+
 #pragma mark UITableViewDataSource Delegate Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView


### PR DESCRIPTION
- Added [ELCAsset assetDeselected:].
- Added [ELCAsset shouldDeselectAsset:].
- Added [ELCAssetSelectionDelegate shouldDeselectAsset:previousCount:].
- Implemented [ELCAlbumPickerController shouldDeselectAsset:previousCount:]
  to forward to parent.

Allows consumer to determine if an image can be deselected or not.  Offers the caller the ability to know when an image was deselected.

In my case, I want to allow for a minimum of two images to be selected.  I'm disabling the "Done" button upon image picker view presentation, and re-enabling it when at least two images have been chosen.  In order to have enough control over this process, I need to know when an image is deselected.
