### PR TITLE
Correction in tapping control in a cell when the maximum number of selec...

### DIFF
--- a/Classes/ELCImagePicker/ELCAlbumPickerController.h
+++ b/Classes/ELCImagePicker/ELCAlbumPickerController.h
@@ -15,6 +15,7 @@
 @property (nonatomic, weak) id<ELCAssetSelectionDelegate> parent;
 @property (nonatomic, strong) NSMutableArray *assetGroups;
 @property (nonatomic, strong) NSArray *mediaTypes;
+@property (strong, nonatomic) ELCAssetTablePicker *picker;
 
 // optional, can be used to filter the assets displayed
 @property (nonatomic, weak) id<ELCAssetPickerFilterDelegate> assetPickerFilterDelegate;

--- a/Classes/ELCImagePicker/ELCAlbumPickerController.m
+++ b/Classes/ELCImagePicker/ELCAlbumPickerController.m
@@ -111,6 +111,15 @@
     return [self.parent shouldDeselectAsset:asset previousCount:previousCount];
 }
 
+- (BOOL)isSelectableIndexNumber:(NSUInteger)indexNumber {
+    
+    if ([self.parent respondsToSelector:@selector(isSelectableIndexNumber:)]) {
+        return [self.parent isSelectableIndexNumber:indexNumber];
+    }else {
+        return NO;
+    }
+}
+
 - (void)selectedAssets:(NSArray*)assets
 {
 	[_parent selectedAssets:assets];

--- a/Classes/ELCImagePicker/ELCAsset.h
+++ b/Classes/ELCImagePicker/ELCAsset.h
@@ -15,6 +15,7 @@
 @optional
 - (void)assetSelected:(ELCAsset *)asset;
 - (BOOL)shouldSelectAsset:(ELCAsset *)asset;
+- (BOOL)isSelectable;
 - (void)assetDeselected:(ELCAsset *)asset;
 - (BOOL)shouldDeselectAsset:(ELCAsset *)asset;
 @end
@@ -25,6 +26,7 @@
 @property (nonatomic, strong) ALAsset *asset;
 @property (nonatomic, weak) id<ELCAssetDelegate> parent;
 @property (nonatomic, assign) BOOL selected;
+@property (nonatomic, readonly, getter = isSelectable) BOOL selectable;
 @property (nonatomic,assign) int index;
 
 - (id)initWithAsset:(ALAsset *)asset;

--- a/Classes/ELCImagePicker/ELCAsset.m
+++ b/Classes/ELCImagePicker/ELCAsset.m
@@ -58,6 +58,15 @@
     }
 }
 
+- (BOOL)isSelectable {
+    
+    if ([_parent respondsToSelector:@selector(isSelectable)]) {
+        return [_parent isSelectable];
+    }else {
+        return NO;
+    }
+}
+
 - (NSComparisonResult)compareWithIndex:(ELCAsset *)_ass
 {
     if (self.index > _ass.index) {

--- a/Classes/ELCImagePicker/ELCAssetCell.m
+++ b/Classes/ELCImagePicker/ELCAssetCell.m
@@ -94,21 +94,30 @@
     
 	CGRect frame = CGRectMake(startX, 2, 75, 75);
 	
-	for (int i = 0; i < [_rowAssets count]; ++i) {
+    for (int i = 0; i < [_rowAssets count]; ++i) {
         if (CGRectContainsPoint(frame, point)) {
             ELCAsset *asset = [_rowAssets objectAtIndex:i];
-            asset.selected = !asset.selected;
             ELCOverlayImageView *overlayView = [_overlayViewArray objectAtIndex:i];
-            overlayView.hidden = !asset.selected;
-            if (asset.selected) {
+            
+            // If the asset is not selected check if it could be selected
+            if (!asset.selected && [asset isSelectable]) {
+                asset.selected = !asset.selected;
+                overlayView.hidden = !asset.selected;
+                
                 asset.index = [[ELCConsole mainConsole] numOfSelectedElements];
                 [overlayView setIndex:asset.index+1];
                 [[ELCConsole mainConsole] addIndex:asset.index];
-            }
-            else
-            {
+            }else if(asset.selected) { // If the asset is going to be unselected
+                asset.selected = !asset.selected;
+                overlayView.hidden = !asset.selected;
+                
+                asset.index = 0;
+                [overlayView setIndex:asset.index];
                 int lastElement = [[ELCConsole mainConsole] numOfSelectedElements] - 1;
                 [[ELCConsole mainConsole] removeIndex:lastElement];
+            }else if (!asset.selected && ![asset isSelectable]) {
+                // If the asset isn't selected and is not selectable, try to select to show a message to the user
+                asset.selected = !asset.selected;
             }
             break;
         }

--- a/Classes/ELCImagePicker/ELCAssetSelectionDelegate.h
+++ b/Classes/ELCImagePicker/ELCAssetSelectionDelegate.h
@@ -15,5 +15,6 @@
 - (void)selectedAssets:(NSArray *)assets;
 - (BOOL)shouldSelectAsset:(ELCAsset *)asset previousCount:(NSUInteger)previousCount;
 - (BOOL)shouldDeselectAsset:(ELCAsset *)asset previousCount:(NSUInteger)previousCount;
+- (BOOL)isSelectableIndexNumber:(NSUInteger)indexNumber;
 
 @end

--- a/Classes/ELCImagePicker/ELCAssetTablePicker.h
+++ b/Classes/ELCImagePicker/ELCAssetTablePicker.h
@@ -23,8 +23,8 @@
 // optional, can be used to filter the assets displayed
 @property(nonatomic, weak) id<ELCAssetPickerFilterDelegate> assetPickerFilterDelegate;
 
+- (void)returnBack;
 - (int)totalSelectedAssets;
-- (void)preparePhotos;
 
 - (void)doneAction:(id)sender;
 

--- a/Classes/ELCImagePicker/ELCAssetTablePicker.m
+++ b/Classes/ELCImagePicker/ELCAssetTablePicker.m
@@ -51,7 +51,7 @@
 	[self performSelectorInBackground:@selector(preparePhotos) withObject:nil];
     
     // Register for notifications when the photo library has changed
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(preparePhotos) name:ALAssetsLibraryChangedNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshAssets) name:ALAssetsLibraryChangedNotification object:nil];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -64,6 +64,15 @@
 {
     [super viewWillDisappear:animated];
     [[ELCConsole mainConsole] removeAllIndex];
+}
+
+- (void)didReceiveMemoryWarning {
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:ALAssetsLibraryChangedNotification object:nil];
+}
+
+- (void)dealloc {
+    
     [[NSNotificationCenter defaultCenter] removeObserver:self name:ALAssetsLibraryChangedNotification object:nil];
 }
 
@@ -104,7 +113,7 @@
                 [self.elcAssets addObject:elcAsset];
             }
 
-         }];
+        }];
 
         dispatch_sync(dispatch_get_main_queue(), ^{
             [self.tableView reloadData];
@@ -124,6 +133,15 @@
     }
 }
 
+- (void)refreshAssets {
+    
+    [self performSelectorInBackground:@selector(preparePhotos) withObject:nil];
+}
+
+- (void)returnBack {
+    
+    [self.navigationController popViewControllerAnimated:YES];
+}
 
 - (void)doneAction:(id)sender
 {	

--- a/Classes/ELCImagePicker/ELCAssetTablePicker.m
+++ b/Classes/ELCImagePicker/ELCAssetTablePicker.m
@@ -93,6 +93,7 @@
     @autoreleasepool {
         
         [self.elcAssets removeAllObjects];
+        [[ELCConsole mainConsole] removeAllIndex];
         [self.assetGroup enumerateAssetsUsingBlock:^(ALAsset *result, NSUInteger index, BOOL *stop) {
             
             if (result == nil) {

--- a/Classes/ELCImagePicker/ELCAssetTablePicker.m
+++ b/Classes/ELCImagePicker/ELCAssetTablePicker.m
@@ -154,6 +154,20 @@
     return shouldSelect;
 }
 
+- (BOOL)isSelectable {
+    
+    NSUInteger selectionCount = 0;
+    for (ELCAsset *elcAsset in self.elcAssets) {
+        if (elcAsset.selected) selectionCount++;
+    }
+    
+    if ([self.parent respondsToSelector:@selector(isSelectableIndexNumber:)]) {
+        return [self.parent isSelectableIndexNumber:selectionCount];
+    }else {
+        return NO;
+    }
+}
+
 - (void)assetSelected:(ELCAsset *)asset
 {
     if (self.singleSelection) {

--- a/Classes/ELCImagePicker/ELCImagePickerController.m
+++ b/Classes/ELCImagePicker/ELCImagePickerController.m
@@ -87,6 +87,11 @@
     return YES;
 }
 
+- (BOOL)isSelectableIndexNumber:(NSUInteger)indexNumber {
+    
+    return (indexNumber < self.maximumImagesCount);
+}
+
 - (void)selectedAssets:(NSArray *)assets
 {
 	NSMutableArray *returnArray = [[NSMutableArray alloc] init];

--- a/Classes/ELCImagePickerDemoViewController.m
+++ b/Classes/ELCImagePickerDemoViewController.m
@@ -25,8 +25,8 @@
 {
 	ELCImagePickerController *elcPicker = [[ELCImagePickerController alloc] initImagePicker];
 
-    elcPicker.maximumImagesCount = 100; //Set the maximum number of images to select to 100
-    elcPicker.returnsOriginalImage = YES; //Only return the fullScreenImage, not the fullResolutionImage
+    elcPicker.maximumImagesCount = 8; //Set the maximum number of images to select to 100
+    elcPicker.returnsOriginalImage = NO; //Only return the fullScreenImage, not the fullResolutionImage
     elcPicker.returnsImage = YES; //Return UIimage if YES. If NO, only return asset location information
     elcPicker.onOrder = YES; //For multiple image selection, display and return order of selected images
     elcPicker.mediaTypes = @[(NSString *)kUTTypeImage, (NSString *)kUTTypeMovie]; //Supports image and movie types


### PR DESCRIPTION
...table elements has been reached

This change prevents that when an user tries to select an asset and it has been reached the maximum number of selectable elements, the cellTapped event recognizer accesses to the section of code when an asset is going to be deselected, discounting an element in the ELCConsole's array and causing a problem with the numbering of the indexes

Signed-off-by: Arturo Arturo@MacBook-Pro-de-Arturo.local
